### PR TITLE
Configure some default security context settings for chart

### DIFF
--- a/chart/trivy-operator-explorer/Chart.yaml
+++ b/chart/trivy-operator-explorer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/trivy-operator-explorer/templates/deployment.yaml
+++ b/chart/trivy-operator-explorer/templates/deployment.yaml
@@ -36,8 +36,6 @@ spec:
               containerPort: {{ .Values.config.port }}
               protocol: TCP
           env:
-            - name: TRIVY_OPERATOR_EXPLORER_METRICS_ENDPOINT
-              value: '{{ .Values.config.metrics_endpoint }}'
             - name: TRIVY_OPERATOR_EXPLORER_LOG_LEVEL
               value: '{{ .Values.config.log_level }}'
             - name: TRIVY_OPERATOR_EXPLORER_SERVER_PORT

--- a/chart/trivy-operator-explorer/values.yaml
+++ b/chart/trivy-operator-explorer/values.yaml
@@ -32,16 +32,17 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 3000
+  fsGroup: 2000
 
-securityContext: {}
+securityContext:
   # capabilities:
   #   drop:
   #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
 service:
   type: ClusterIP

--- a/chart/trivy-operator-explorer/values.yaml
+++ b/chart/trivy-operator-explorer/values.yaml
@@ -33,14 +33,28 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext:
-  runAsUser: 1000
-  runAsGroup: 3000
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
+  runAsUser: 10001
+  runAsGroup: 30000
   fsGroup: 2000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
 securityContext:
-  # capabilities:
-  #   drop:
-  #   - ALL
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
+  runAsUser: 10001
+  runAsGroup: 30000
+  fsGroup: 2000
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
 
@@ -58,23 +72,20 @@ ingress:
     - host: chart-example.local
       paths:
         - path: /
-          pathType: ImplementationSpecific
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources: 
+  # Change these as needed. Larger clusters with more resources may run into issues with too low of limits.
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
This is mostly to address security concerns that Trivy Operator itself actually identified in this chart. The securityContext and podSecurityContext are duplicated because Trivy Operator will argue those settings should be in both places.