### PR TITLE
Unset limits in helm charts - leave configuration to cluster operators

### DIFF
--- a/chart/trivy-operator-collector/Chart.yaml
+++ b/chart/trivy-operator-collector/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed.
 appVersion: "v1.0.0"

--- a/chart/trivy-operator-collector/values.yaml
+++ b/chart/trivy-operator-collector/values.yaml
@@ -64,12 +64,12 @@ securityContext:
   readOnlyRootFilesystem: true
 
 resources:
-  limits:
-    cpu: 500m
-    memory: 256Mi
+  # limits:
+  #   cpu: 500m
+  #   memory: 256Mi
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 128Mi
 
 nodeSelector: {}
 

--- a/chart/trivy-operator-explorer/Chart.yaml
+++ b/chart/trivy-operator-explorer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/trivy-operator-explorer/values.yaml
+++ b/chart/trivy-operator-explorer/values.yaml
@@ -138,9 +138,9 @@ mcpIngress:
 
 resources: 
   # Change these as needed. Larger clusters with more resources may run into issues with too low of limits.
-  limits:
-    cpu: 500m
-    memory: 512Mi
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
   requests:
     cpu: 100m
     memory: 64Mi


### PR DESCRIPTION
Because the memory usage of this explorer/collector are highly subject to cluster size (by number of vulnerabilities in each running image) it is not useful to set baseline limits in the chart. Leaving that prescription to cluster operators instead of trying to set a baseline that would be different for every cluster.